### PR TITLE
Compile against Rocket master branch

### DIFF
--- a/rocket/Cargo.toml
+++ b/rocket/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2018"
 
 [dependencies]
 # rocket = "0.4.3"
-rocket = { git = "https://github.com/SergioBenitez/Rocket.git", branch = "async" }
+rocket = { git = "https://github.com/SergioBenitez/Rocket.git" }
+tokio = "0.2"

--- a/rocket/src/main.rs
+++ b/rocket/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene, decl_macro)]
-
 #[macro_use]
 extern crate rocket;
 
@@ -8,6 +6,11 @@ fn hello() -> String {
     format!("Hello, World!")
 }
 
-fn main() {
-    rocket::ignite().mount("/", routes![hello]).launch();
+#[tokio::main]
+async fn main() {
+    rocket::custom(rocket::Config::figment().merge(("port", 8081)))
+        .mount("/", routes![hello])
+        .launch()
+        .await
+        .expect("Run Rocket");
 }


### PR DESCRIPTION
This change makes the rocket prototype compile against master branch and changes the port it listens on to match the other prototypes.

Side note: performance of the rocket implementation is way more decent nowadays.